### PR TITLE
fix: patch erlpack for node 16

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,6 @@
     "typescript": "^4.4.3"
   },
   "optionalDependencies": {
-    "erlpack": "^0.1.3"
+    "erlpack": "github:almeidx/erlpack#f0c535f73817fd914806d6ca26a7730c14e0fb7c"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1995,10 +1995,9 @@ enquirer@^2.3.5, enquirer@^2.3.6:
   dependencies:
     ansi-colors "^4.1.1"
 
-erlpack@^0.1.3:
+"erlpack@github:almeidx/erlpack#f0c535f73817fd914806d6ca26a7730c14e0fb7c":
   version "0.1.3"
-  resolved "https://registry.yarnpkg.com/erlpack/-/erlpack-0.1.3.tgz#f6cd2a0d5b2f9d054b310c1dda98f60744b9f857"
-  integrity sha512-QeG9v8CVsY/a/IoQi8zjn23aYKcziOihAxwjUl3tI/KB4R1FjTtctDAAMovgtpC16S+WiOauers2oWwIOQtKBQ==
+  resolved "https://codeload.github.com/almeidx/erlpack/tar.gz/f0c535f73817fd914806d6ca26a7730c14e0fb7c"
   dependencies:
     bindings "^1.5.0"
     nan "^2.14.0"


### PR DESCRIPTION
**What did you change in this PR?**
Updated erlpack to a patched version

**Why should this change be made?**
Erlpack doesn't build on the latest version of node

**Why should we accept this change?**
See the previous step

**Additional context**
![image](https://user-images.githubusercontent.com/42935195/135639542-2a196169-4004-4c72-8772-0f1b20e05673.png)
