### PR TITLE
Fixed typo in en-US

### DIFF
--- a/locales/en-US/commands.json
+++ b/locales/en-US/commands.json
@@ -21,7 +21,7 @@
     "description": "Bite someone :3",
     "usage": "<@mention>",
     "bot": "You bit a robot ... -5 teeth in the mouth",
-    "self-mention": "Ooo look at the the masochist, do it right now, no command needed",
+    "self-mention": "Ooo look at the masochist, do it right now, no command needed",
     "embed_title": "Bites",
     "embed_description": "{{author}} bit {{mention}}"
   },


### PR DESCRIPTION
**What did you change in this PR?**
fixed typo(`the the` -> `the`)

**Why should this change be made?**
I'll omit it because it's just a Typo fix.

**Why should we accept this change?**
same as above.

**Additional context**

