### PR TITLE
`calculateProbability()` faster and leaner

### DIFF
--- a/packages/events/src/modules/hunt/huntUtils.ts
+++ b/packages/events/src/modules/hunt/huntUtils.ts
@@ -50,18 +50,12 @@ const getUserHuntCooldown = (
 const calculateProbability = (probabilities: HuntProbabiltyProps[]): number => {
   const chance = Math.floor(Math.random() * 100);
 
-  let accumulator = probabilities.reduce((p, c) => p + c.probability, 0);
-
-  const mapedChanges: { amount: number; probabilities: number[] }[] = probabilities.map((a) => {
-    const toReturn = [accumulator - a.probability, accumulator];
-    accumulator -= a.probability;
-    return { amount: a.amount, probabilities: toReturn };
-  });
+  let accumulator = 100;
 
   // eslint-disable-next-line no-restricted-syntax
-  for (const data of mapedChanges) {
-    const [min, max] = data.probabilities;
-    if (chance >= min && chance <= max) {
+  for (const data of probabilities) {
+    accumulator -= data.probability;
+    if (chance >= accumulator) {
       return data.amount;
     }
   }


### PR DESCRIPTION
1. There is no need to store `probabilities` in the array `mapedChanges` and then iterate over it. Instead, iterations can be done directly on `probabilities`.
2. The variable `accumulator` is initialized with "100" instead of `probabilities.reduce((p, c) => p + c.probability, 0)`. This avoids performing an unnecessary additional operation.
3. The comparison logic has been changed to `chance >= accumulator` instead of `chance >= min && chance <= max`. This is possible because accumulator is updated on each iteration instead of at the end.

PS. This is only a suggestion for improvement and should be tested according to the needs of the rest of the code.